### PR TITLE
Docs: Correct the markdown_source for outreach/articles

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -212,7 +212,7 @@
 	{
 		"title": "Articles",
 		"slug": "articles",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/outreach/docs/articles.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/outreach/articles.md",
 		"parent": "outreach"
 	},
 	{


### PR DESCRIPTION
## Description
The edit link on https://wordpress.org/gutenberg/handbook/outreach/articles/ is pointing to the incorrect URL - as reported in https://meta.trac.wordpress.org/ticket/3787